### PR TITLE
WIP: Document how Packit team kanbanz

### DIFF
--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -1,0 +1,51 @@
+# Meetings
+
+Our team meetings are organised similarly each week. We have standup meetings on Monday, Tuesday and Thursday morning and all the other team meetings happen on Thursdays to make our team schedule compact.
+
+## Standups
+
+We have standups 3 times a week (Mondays, Tuesdays and Thursdays) to talk about issues we are facing and what we are planning to work on next. Reserve the other 2 days for focus time.
+
+1. Each standup, we start with checking the new cards in our [Kanban board](https://github.com/orgs/packit/projects/7). On Mondays, we also go through the blocked cards and cards that haven't had any progress for a while to see if we can do anything with them.
+2. To avoid stale issues, we discuss also one least recently updated issue from the backlog and check if it's still relevant.
+3. We follow with the statuses -- everyone quickly shares what they were working on recently, what are working on and planning to do next. Also if there are any issues or blockers found on the way. This should be a monologue to make the most of the time. Any topic requiring more discussion is left to be discussed elsewhere (separate discussion/meeting or [architecture meeting](TBD link)) or discussed at the end of the standup.
+4. For each standup, we have a standup question defined to engage a bit. Everyone answers the question after providing a status. It can be any warm-up question or short activity. Sometimes, it's just for fun, sometimes it allows us to show our current mood or energy level. This also makes us know others more building a stronger team together.
+5. So-called post-standup topics are discussed. To not disturb statuses, any announcement or topic requiring a discussion/response is left to the end of the meeting.
+
+## Architecture meeting
+
+To not make standup meetings too long, we've separated the longer discussion into a weekly organised meeting. As the name suggests, the main goal of this meeting is to discuss technical or architectural topics but there is a place to discuss anything. The topics are collected beforehand in a shared document. Alternatively, anyone can add a "discuss" label to an issue.
+
+[Kanban lead](TBD) facilitates the discussion and shows a 5-minute timer for each topic (can be reset if everyone agrees to continue with a discussion). Kanban lead is also responsible for note-taking and making a clear conclusion from the discussion including the clear action items. Anyone is welcome to help with the notes since sometimes it's hard to facilitate discussion and make notes at one time.
+
+Meetings are safe space. There are no dumb ideas or stupid questions - anyone can ask if they don’t understand something.
+
+:::tip
+If there is a strong decision needed, let people provide feedback also offline (either before or after the meeting). Some people might prefer written communication and/or asynchronous communication. Allow them to participate so the best decision is chosen.
+:::
+
+## Refinement meeting
+
+Weekly meetings to prepare our next cards to work on. This is not to **_plan_** the work for the next week as done in Scrum. Kanban is based on a stream of cards going through the board columns. This activity is about moving the card from the top of the backlog (a priority one in our case) into the _refined_ column so they can be taken by anyone to start the real work.
+
+When refining, we need to make sure that the card is clearly defined (i.e. **anyone** can work on the card), there is a clear definition of done and the card is doable in 5 or fewer days.
+
+The discussion starts with a quick introduction of the card (done by a [Kanban lead](TBD) or a person the most familiar with the task). The card is being updated and the discussion continues until we agree it's clear and can be done in 5 days or less -- to help ourselves reach this agreement, there is a voting going on. We used to do a thumbs-up/down for the following questions:
+
+1. Is this card clear?
+2. Is this doable in 5 days or less?
+
+Since there wasn't much disagreement and discussion, we switched to Scrum-like voting by hand about story points. (A difference in story points helps us better find a difference in the understanding.) We collect the story points but it's not the main reason why we do the voting. Be respectful when asking people why they've chosen a different story point number. It's to help everyone with the understanding and also to share the possible risks, not to put anyone in a spot!
+
+Mark cards worth demoing with a `demo` label – either for the public or for the team to share knowledge.
+
+At the end of the meeting, make sure the order (=priority) of the cards in the _refined_ column is right and respects our priorities as shown on the [epic board](https://github.com/orgs/packit/projects/7/views/29).
+
+## Retrospectives
+
+Bi-weekly meetings to get a sense of how everyone feels. This is a safe space -- feel free to share anything openly and also be open to listening to others.
+
+Miro board is created by the Kanban Lead leading the Retrospective at the beginning of the week (ideally Monday morning) to provide time for adding notes to the board in advance.
+There's a default Miro board template prepared, but any activity or board can be used to make it more interesting.
+
+Action items from the previous retro board should be included to be discussed and checked.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,38 @@
+# Packit team roles
+
+In our team, we have a few statically assigned roles but as much as possible is shared within a team in the form of weekly-rotated roles. We don't rotate the roles of Product Owner and Technical Leader to give the team a long-term perspective. Having both a Product Owner and a Technical Leader allows us to balance the user-targeted view with the implementation perspective. Despite of having those two roles assigned, everyone is welcome to help (e.g. Community Shepherd helps with the daily communication with our users).
+
+## Product Owner
+
+The role of the Product Owner is here to represent the user perspective and make sure the work being done by the team benefits our users. They also define the vision and high-level architecture of the project. The main liaison with stakeholders and consumers.
+
+## Technical Leader
+
+A technical leader understands the project and all its parts to an extent to be able to make technical decisions or drive the team to make them in a timely and reasonable manner. Responsible for the technical solution being scalable, efficient and secure. Works with PO on breaking down epics into smaller tasks. Responsible for tracking the development status and making sure things go hand in hand with the quarterly plans.
+
+## Weekly roles
+
+Here are the roles that are rotated each week.
+(Check [this page](./weekly-roles) for the automation we use for it.)
+The specific tasks are defined in the form of [issues](https://github.com/packit/agile/issues?q=is%3Aissue+is%3Aopen+label%3Aroles).
+
+:::note
+This is our specific and currently used setup tweaked to our needs and the current number of team members.
+We update this now and then but the basic structure and idea stay the same.
+:::
+
+### Service Guru
+
+This person is responsible for a weekly deployment of Packit service and other related activities (e.g. a blog post).
+
+### Community Shepherd
+
+Community Shepherd is present on our communication channels and available to help people or forward questions to other team members.
+
+### Release Responsible
+
+The person who does the releases of our projects (both on GitHub and in Fedora).
+
+### Kanban Lead
+
+Kanban lead is a moderator of all the [meetings](./meetings) during the week and prepares them (e.g. a standup question or a retrospective board/activity).


### PR DESCRIPTION
- [ ] Make the role definition more detailed.
- [ ] Add [this diagram](https://miro.com/app/board/uXjVMKkRUiE=/) of the role responsibilities. 
- [ ] Add a main page.
- [ ] Document labels and rules how they are chosen
- [ ] Document planning/prioritisation process.


<!-- release notes footer -->

RELEASE NOTES BEGIN

The Packit team agile practices are newly documented at https://packit.dev/agile

RELEASE NOTES END
