### PR TITLE
Rework Skald as independent role with fixed rotation order

### DIFF
--- a/clone_roles.py
+++ b/clone_roles.py
@@ -1,26 +1,27 @@
+from __future__ import annotations
+
 import logging
 import os
 import random
-from typing import List, Optional, Mapping
 
 from ogr.abstract import IssueStatus, Issue
 from ogr.services.github.project import GithubProject
 from ogr.services.github.service import GithubService
 
 ROLE_LABEL = "kind/role"
-ISSUE_TITLES = [
+WEEKLY_ROLES = [
     "Service Guru",
     "Release Responsible",
     "Chief of Monitors",
     "Kanban Lead",
     "Community Shepherd",
 ]
-MAINTAINERS_ALLOWED_JOBS = {
-    "majamassarini": ISSUE_TITLES,  # Can do any job
-    "lbarcziova": ISSUE_TITLES,
-    "mfocko": ISSUE_TITLES,
-    "nforro": ISSUE_TITLES,
+INDEPENDENT_ROLE_ROTATIONS = {
+    "Skald": ["lbarcziova", "majamassarini", "opohorel", "TomasTomecek", "nforro"],
 }
+INDEPENDENT_ROLES = list(INDEPENDENT_ROLE_ROTATIONS)
+ISSUE_TITLES = WEEKLY_ROLES + INDEPENDENT_ROLES
+WEEKLY_MAINTAINERS = ["majamassarini", "lbarcziova", "mfocko", "nforro"]
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -31,97 +32,102 @@ class RotationHelper:
         self.weekly_roles_project: GithubProject = GithubService(
             token=token
         ).get_project(repo="agile", namespace="packit")
+        self._all_role_issues = None
         self._previous_week_issues = None
+
+    @property
+    def all_role_issues(self):
+        if self._all_role_issues is None:
+            self._all_role_issues = self.weekly_roles_project.get_issue_list(
+                labels=[ROLE_LABEL], status=IssueStatus.all
+            )
+            self._all_role_issues.sort(key=lambda issue: issue.created, reverse=True)
+        return self._all_role_issues
 
     @property
     def previous_week_issues(self):
         if not self._previous_week_issues:
-            issues = self.weekly_roles_project.get_issue_list(
-                labels=[ROLE_LABEL], status=IssueStatus.all
-            )
-            # sort the issues by created attribute from the newest
-            issues.sort(key=lambda issue: issue.created, reverse=True)
             self._previous_week_issues = [
-                self.get_issue_by_title(issue_title, issues)
+                self.get_issue_by_title(issue_title, self.all_role_issues)
                 for issue_title in ISSUE_TITLES
             ]
         return self._previous_week_issues
 
     @staticmethod
-    def get_issue_by_title(title: str, issues: List[Issue]):
+    def get_issue_by_title(title: str, issues: list[Issue]):
         # issues are sorted from the most recently created
         # so the first found is the most recent
         return next(issue for issue in issues if issue.title == title)
 
-    def get_last_done_job(self) -> Mapping[str, Optional[str]]:
-        maintainers_last_job = {k: None for k in MAINTAINERS_ALLOWED_JOBS.keys()}
+    def get_last_done_job(self) -> dict[str, str | None]:
+        last_job: dict[str, str | None] = {m: None for m in WEEKLY_MAINTAINERS}
         for issue in self.previous_week_issues:
-            job_title = issue.title
+            if issue.title in INDEPENDENT_ROLES:
+                continue
             assignee = issue.assignees[0].login if issue.assignees else None
-            if assignee in maintainers_last_job:
-                maintainers_last_job[assignee] = job_title
-        return maintainers_last_job
+            if assignee in last_job:
+                last_job[assignee] = issue.title
+        return last_job
 
     def choose_maintainer(
         self,
         job_title: str,
-        maintainers_last_job: Mapping[str, Optional[str]],
-        already_assigned: List[str],
+        maintainers_last_job: dict[str, str | None],
+        already_assigned: list[str],
     ) -> str:
-        eligible_maintainers = []
-        for maintainer, jobs in MAINTAINERS_ALLOWED_JOBS.items():
-            if job_title in jobs and maintainer not in already_assigned:
-                eligible_maintainers.append(maintainer)
+        eligible = [m for m in WEEKLY_MAINTAINERS if m not in already_assigned]
+        if not eligible:
+            eligible = list(WEEKLY_MAINTAINERS)
 
-        # If no eligible maintainers are available (all already assigned),
-        # we need to pick someone who can do this job even if they're already assigned
-        if not eligible_maintainers:
-            for maintainer, jobs in MAINTAINERS_ALLOWED_JOBS.items():
-                if job_title in jobs:
-                    eligible_maintainers.append(maintainer)
+        best_fits = [m for m in eligible if maintainers_last_job[m] is None]
+        if best_fits:
+            return random.choice(best_fits)
 
-        # If maintainers have done nothing previous week, choose between them
         best_fits = []
-        for maintainer in eligible_maintainers:
-            if maintainers_last_job[maintainer] is None:
-                best_fits.append(maintainer)
+        for m in eligible:
+            last = maintainers_last_job[m]
+            if last and last in WEEKLY_ROLES:
+                next_idx = (WEEKLY_ROLES.index(last) + 1) % len(WEEKLY_ROLES)
+                if WEEKLY_ROLES[next_idx] == job_title:
+                    best_fits.append(m)
 
         if best_fits:
             return random.choice(best_fits)
 
-        # If maintainers' next role is this, choose between them
-        best_fits = []
-        for maintainer in eligible_maintainers:
-            jobs = MAINTAINERS_ALLOWED_JOBS[maintainer]
-            last_job = maintainers_last_job[maintainer]
-            if last_job and last_job in jobs:
-                new_job_index = (jobs.index(last_job) + 1) % len(jobs)
-                if jobs[new_job_index] == job_title:
-                    best_fits.append(maintainer)
+        return random.choice(eligible)
 
-        if best_fits:
-            return random.choice(best_fits)
+    def choose_independent_role(self, job_title: str) -> str:
+        rotation = INDEPENDENT_ROLE_ROTATIONS[job_title]
+        for issue in self.all_role_issues:
+            if issue.title == job_title and issue.assignees:
+                last_assignee = issue.assignees[0].login
+                if last_assignee in rotation:
+                    idx = rotation.index(last_assignee)
+                    return rotation[(idx + 1) % len(rotation)]
+        return rotation[0]
 
-        # Otherwise choose between all eligible
-        return random.choice(eligible_maintainers)
-
-    def rotate_roles(self) -> List[str]:
+    def rotate_roles(self) -> list[str]:
         """
         Finds eligible maintainers who can do the job.
         Prioritizes maintainers who didn't have a job last time.
         If all eligible maintainers had jobs, it finds the next job in rotation for each maintainer.
-        If no clear next-in-rotation, it picks randomly
+        If no clear next-in-rotation, it picks randomly.
+        Independent roles (e.g. Skald) follow a fixed rotation order,
+        advancing to the next person based on the current assignee.
         """
         maintainers_last_job = self.get_last_done_job()
         maintainers = []
-        already_assigned: List[str] = []
+        already_assigned: list[str] = []
 
         for job_title in ISSUE_TITLES:
-            maintainer = self.choose_maintainer(
-                job_title, maintainers_last_job, already_assigned
-            )
+            if job_title in INDEPENDENT_ROLES:
+                maintainer = self.choose_independent_role(job_title)
+            else:
+                maintainer = self.choose_maintainer(
+                    job_title, maintainers_last_job, already_assigned
+                )
+                already_assigned.append(maintainer)
             maintainers.append(maintainer)
-            already_assigned.append(maintainer)
 
         return maintainers
 

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -132,7 +132,7 @@ Process of handling new cards and categorizing them.
 3. Prioritising
    1. **_Is there a strict deadline? Did we break anything crucial? Are we significantly blocking users?_** => [Refine the card](#Refine) right away and move to the `refined` column.
    2. **_Is there a `gain/high` and `impact/high` label? Do we need/want to finish this within ~3 months? Is this part of our current high-level plans for the quarter?_** => Move to the `priority-backlog` (To Do) state.
-   3. **_Is there a workaround? Doesn't the task make a user start/stop using Packit? Or, otherwise. _** => move to the `backlog` state.
+   3. **\_Is there a workaround? Doesn't the task make a user start/stop using Packit? Or, otherwise. _** => move to the `backlog` state.
 
 ### Refine
 


### PR DESCRIPTION
Two separate rotation systems now:

Weekly roles (Service Guru, Release Responsible, etc.) rotate among majamassarini, lbarcziova, mfocko and nforro using the existing priority logic (idle maintainers first, then next-in-rotation, then random).

Skald rotates independently in a fixed cycle: lbarcziova → majamassarini → opohorel → TomasTomecek → nforro. The script looks up the current Skald assignee and picks the next person. One person can hold both a weekly role and Skald in the same week.

Also fixes a bug where get_last_done_job() would overwrite a maintainer's weekly role with "Skald" if they had both, breaking weekly rotation priorities.

Assisted-by: Claude Opus 4.6
