### PR TITLE
Syncing Jira tickets to GitHub issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Mark devenv.sh lockfiles as generated, so they don’t pollute diffs
+devenv.lock linguist-generated

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,5 @@ repos:
     rev: v1.19.1
     hooks:
       - id: mypy
+        additional_dependencies:
+          - types-requests

--- a/jira-to-gh/.gitignore
+++ b/jira-to-gh/.gitignore
@@ -1,0 +1,10 @@
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/jira-to-gh/devenv.lock
+++ b/jira-to-gh/devenv.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1785772008,
+        "narHash": "sha256-xVVP8WR9/yQ0AvvVQMeMQbHrHXJTKBq7dqcPyphXDek=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "9d93b838def889d5bcff302cac49c9322d34d33c",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1785855293,
+        "narHash": "sha256-oFTyNNuuFPL6KXd1D0w4K+IHmKIiXtCMdlnoc9vXkTk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "6d5d03d1dfd5f530a098832d0f5433479b576278",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784686015,
+        "narHash": "sha256-HpbHqOrLbDS+ZTK2u9iojvWfMlWnuPzGb9XGcEipIxE=",
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "8d51e95247ca71680b72cdd308fdf1dbeb031313",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785715447,
+        "narHash": "sha256-4K0IGmbAOJnd/Hx2+CNEvx3ECrtYnsoaf4grI6gvZ/Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "243895692ae2a2fbd08a05141462c0cc0d3ca10f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/jira-to-gh/devenv.nix
+++ b/jira-to-gh/devenv.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  packages = with pkgs; [
+    gh
+  ];
+
+  languages.python = {
+    enable = true;
+    version = "3.14";
+    venv = {
+      enable = true;
+      requirements = ''
+        click
+        requests
+        tqdm
+      '';
+    };
+  };
+}

--- a/jira-to-gh/devenv.yaml
+++ b/jira-to-gh/devenv.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/jira-to-gh/sync.py
+++ b/jira-to-gh/sync.py
@@ -13,13 +13,14 @@ Authentication:
 Usage:
   export JIRA_EMAIL=you@redhat.com
   export JIRA_TOKEN=...
-  ./sync_jira_to_github.py
-  ./sync_jira_to_github.py --dry-run
+  ./sync.py
+  ./sync.py --dry-run
+  ./sync.py --jql 'project = PACKIT AND labels = "custom"'
+  ./sync.py --url https://your.atlassian.net
 """
 
 from __future__ import annotations
 
-import argparse
 import json
 import os
 import re
@@ -27,6 +28,7 @@ import subprocess
 import sys
 from typing import Any, Iterator
 
+import click
 import requests
 from tqdm import tqdm
 
@@ -208,46 +210,36 @@ def set_jira_field(issue_node_id: str, jira_ticket: str, dry_run: bool) -> bool:
     return True
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Set the 'Jira ticket' GitHub issue field from Jira upstream tickets.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print what would be updated without making any changes.",
-    )
-    parser.add_argument(
-        "--jql",
-        default=None,
-        help="Override the JQL query used to fetch Jira issues.",
-    )
-    parser.add_argument(
-        "--url",
-        default=os.environ.get("JIRA_URL", DEFAULT_JIRA_URL),
-        help=f"Jira base URL (env JIRA_URL, default: {DEFAULT_JIRA_URL}).",
-    )
-    return parser.parse_args()
-
-
-def main() -> int:
-    args = parse_args()
-
+@click.command()
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print what would be updated without making any changes.",
+)
+@click.option(
+    "--jql",
+    default=None,
+    help="Override the JQL query used to fetch Jira issues.",
+)
+@click.option(
+    "--url",
+    default=os.environ.get("JIRA_URL", DEFAULT_JIRA_URL),
+    help=f"Jira base URL (env JIRA_URL, default: {DEFAULT_JIRA_URL}).",
+)
+def main(dry_run: bool, jql: str | None, url: str) -> None:
     email = os.environ.get("JIRA_EMAIL")
     token = os.environ.get("JIRA_TOKEN")
     if not email or not token:
-        print(
+        raise click.ClickException(
             "Set JIRA_EMAIL and JIRA_TOKEN environment variables.\n"
-            "Create a token at: https://id.atlassian.com/manage-profile/security/api-tokens",
-            file=sys.stderr,
+            "Create a token at: https://id.atlassian.com/manage-profile/security/api-tokens"
         )
-        return 1
 
-    jql = args.jql or DEFAULT_JQL
+    jql = jql or DEFAULT_JQL
 
-    print(f"# JQL: {jql}", file=sys.stderr)
-    if args.dry_run:
-        print("# Dry run — no changes will be made.", file=sys.stderr)
+    click.echo(f"# JQL: {jql}", err=True)
+    if dry_run:
+        click.echo("# Dry run — no changes will be made.", err=True)
 
     updated = 0
     skipped = 0
@@ -255,11 +247,9 @@ def main() -> int:
 
     # Collect all (jira_key, owner, repo, number) tuples across all Jira issues.
     pending: list[tuple[str, str, str, int]] = []
-    for issue in tqdm(
-        iter_issues(args.url, email, token, jql), desc="Fetching web links"
-    ):
+    for issue in tqdm(iter_issues(url, email, token, jql), desc="Fetching web links"):
         key = issue["key"]
-        web_links = fetch_web_links(args.url, email, token, key)
+        web_links = fetch_web_links(url, email, token, key)
         for link in web_links:
             m = GITHUB_ISSUE_RE.match(link)
             if m:
@@ -280,28 +270,29 @@ def main() -> int:
 
     for key, owner, repo, number in inaccessible:
         gh_url = f"https://github.com/{owner}/{repo}/issues/{number}"
-        print(f"{key}")
-        print(f"  SKIP  {gh_url}  (issue not found or no access)")
+        click.echo(f"{key}")
+        click.echo(f"  SKIP  {gh_url}  (issue not found or no access)")
         skipped += 1
 
     for sort_ts, key, node_id, owner, repo, number in enriched:
         gh_url = f"https://github.com/{owner}/{repo}/issues/{number}"
-        print(f"{key}")
-        action = "DRY-RUN" if args.dry_run else "SET"
-        ok = set_jira_field(node_id, key, args.dry_run)
+        click.echo(f"{key}")
+        action = "DRY-RUN" if dry_run else "SET"
+        ok = set_jira_field(node_id, key, dry_run)
         if ok:
-            print(f"  {action}  {gh_url}  -> Jira ticket: {key}")
+            click.echo(f"  {action}  {gh_url}  -> Jira ticket: {key}")
             updated += 1
         else:
-            print(f"  ERROR  {gh_url}")
+            click.echo(f"  ERROR  {gh_url}", err=True)
             errors += 1
 
-    print(
+    click.echo(
         f"\nDone: {updated} updated, {skipped} skipped, {errors} errors.",
-        file=sys.stderr,
+        err=True,
     )
-    return 0 if errors == 0 else 1
+    if errors != 0:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()

--- a/jira-to-gh/sync.py
+++ b/jira-to-gh/sync.py
@@ -20,17 +20,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import base64
 import json
 import os
 import re
 import subprocess
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
 from typing import Any, Iterator
 
+import requests
 from tqdm import tqdm
 
 DEFAULT_JIRA_URL = "https://redhat.atlassian.net"
@@ -46,48 +43,34 @@ JIRA_TICKET_FIELD_ID = "IFT_kgDOArAWcw"
 GITHUB_ISSUE_RE = re.compile(r"https://github\.com/([^/]+)/([^/]+)/issues/(\d+)")
 
 
-def auth_headers(email: str, token: str) -> dict[str, str]:
-    credentials = base64.b64encode(f"{email}:{token}".encode()).decode()
-    return {
-        "Authorization": f"Basic {credentials}",
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
-
-
-def jira_get(url: str, headers: dict[str, str]) -> Any:
-    request = urllib.request.Request(url, headers=headers, method="GET")
+def jira_get(url: str, email: str, token: str) -> Any:
     try:
-        with urllib.request.urlopen(request) as response:
-            return json.load(response)
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode(errors="replace")
-        raise SystemExit(f"Jira API error {exc.code} for {url}:\n{detail}") from exc
-    except urllib.error.URLError as exc:
-        raise SystemExit(f"Failed to reach Jira at {url}: {exc.reason}") from exc
+        response = requests.get(url, auth=(email, token))
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as exc:
+        raise SystemExit(
+            f"Jira API error {exc.response.status_code} for {url}:\n{exc.response.text}"
+        ) from exc
+    except requests.exceptions.RequestException as exc:
+        raise SystemExit(f"Failed to reach Jira at {url}: {exc}") from exc
 
 
-def jira_post(
-    url: str, headers: dict[str, str], body: dict[str, Any]
-) -> dict[str, Any]:
-    request = urllib.request.Request(
-        url,
-        data=json.dumps(body).encode(),
-        headers=headers,
-        method="POST",
-    )
+def jira_post(url: str, email: str, token: str, body: dict[str, Any]) -> dict[str, Any]:
     try:
-        with urllib.request.urlopen(request) as response:
-            return json.load(response)
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode(errors="replace")
-        raise SystemExit(f"Jira API error {exc.code} for {url}:\n{detail}") from exc
-    except urllib.error.URLError as exc:
-        raise SystemExit(f"Failed to reach Jira at {url}: {exc.reason}") from exc
+        response = requests.post(url, json=body, auth=(email, token))
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as exc:
+        raise SystemExit(
+            f"Jira API error {exc.response.status_code} for {url}:\n{exc.response.text}"
+        ) from exc
+    except requests.exceptions.RequestException as exc:
+        raise SystemExit(f"Failed to reach Jira at {url}: {exc}") from exc
 
 
 def iter_issues(
-    jira_url: str, headers: dict[str, str], jql: str
+    jira_url: str, email: str, token: str, jql: str
 ) -> Iterator[dict[str, Any]]:
     search_url = f"{jira_url.rstrip('/')}/rest/api/3/search/jql"
     next_page_token: str | None = None
@@ -101,7 +84,7 @@ def iter_issues(
         if next_page_token:
             body["nextPageToken"] = next_page_token
 
-        data = jira_post(search_url, headers, body)
+        data = jira_post(search_url, email, token, body)
         yield from data.get("issues", [])
 
         next_page_token = data.get("nextPageToken")
@@ -109,11 +92,9 @@ def iter_issues(
             break
 
 
-def fetch_web_links(
-    jira_url: str, headers: dict[str, str], issue_key: str
-) -> list[str]:
+def fetch_web_links(jira_url: str, email: str, token: str, issue_key: str) -> list[str]:
     url = f"{jira_url.rstrip('/')}/rest/api/3/issue/{issue_key}/remotelink"
-    links = jira_get(url, headers)
+    links = jira_get(url, email, token)
     return [
         link["object"]["url"] for link in links if (link.get("object") or {}).get("url")
     ]
@@ -263,7 +244,6 @@ def main() -> int:
         return 1
 
     jql = args.jql or DEFAULT_JQL
-    headers = auth_headers(email, token)
 
     print(f"# JQL: {jql}", file=sys.stderr)
     if args.dry_run:
@@ -275,9 +255,11 @@ def main() -> int:
 
     # Collect all (jira_key, owner, repo, number) tuples across all Jira issues.
     pending: list[tuple[str, str, str, int]] = []
-    for issue in tqdm(iter_issues(args.url, headers, jql), desc="Fetching web links"):
+    for issue in tqdm(
+        iter_issues(args.url, email, token, jql), desc="Fetching web links"
+    ):
         key = issue["key"]
-        web_links = fetch_web_links(args.url, headers, key)
+        web_links = fetch_web_links(args.url, email, token, key)
         for link in web_links:
             m = GITHUB_ISSUE_RE.match(link)
             if m:

--- a/jira-to-gh/sync.py
+++ b/jira-to-gh/sync.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Sync Jira ticket URLs onto linked GitHub issues.
+
+For every PACKIT Jira ticket with the ``upstream`` label, fetches its web
+links (remote links), finds any that point to GitHub issues, and sets the
+``Jira ticket`` issue field on those GitHub issues to the Jira ticket URL.
+
+Authentication:
+  JIRA_EMAIL  – Atlassian account email (required)
+  JIRA_TOKEN  – Atlassian API token (required)
+  GITHUB_TOKEN – GitHub token with repo + org access (required, or use `gh auth`)
+
+Usage:
+  export JIRA_EMAIL=you@redhat.com
+  export JIRA_TOKEN=...
+  ./sync_jira_to_github.py
+  ./sync_jira_to_github.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Iterator
+
+from tqdm import tqdm
+
+DEFAULT_JIRA_URL = "https://redhat.atlassian.net"
+DEFAULT_JQL = (
+    'project = PACKIT AND labels = "upstream" AND labels != "closed-upstream"'
+    " AND statusCategory != Done ORDER BY key ASC"
+)
+PAGE_SIZE = 100
+FIELDS = ["summary"]
+
+JIRA_TICKET_FIELD_ID = "IFT_kgDOArAWcw"
+
+GITHUB_ISSUE_RE = re.compile(r"https://github\.com/([^/]+)/([^/]+)/issues/(\d+)")
+
+
+def auth_headers(email: str, token: str) -> dict[str, str]:
+    credentials = base64.b64encode(f"{email}:{token}".encode()).decode()
+    return {
+        "Authorization": f"Basic {credentials}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def jira_get(url: str, headers: dict[str, str]) -> Any:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise SystemExit(f"Jira API error {exc.code} for {url}:\n{detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Failed to reach Jira at {url}: {exc.reason}") from exc
+
+
+def jira_post(
+    url: str, headers: dict[str, str], body: dict[str, Any]
+) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise SystemExit(f"Jira API error {exc.code} for {url}:\n{detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Failed to reach Jira at {url}: {exc.reason}") from exc
+
+
+def iter_issues(
+    jira_url: str, headers: dict[str, str], jql: str
+) -> Iterator[dict[str, Any]]:
+    search_url = f"{jira_url.rstrip('/')}/rest/api/3/search/jql"
+    next_page_token: str | None = None
+
+    while True:
+        body: dict[str, Any] = {
+            "jql": jql,
+            "maxResults": PAGE_SIZE,
+            "fields": FIELDS,
+        }
+        if next_page_token:
+            body["nextPageToken"] = next_page_token
+
+        data = jira_post(search_url, headers, body)
+        yield from data.get("issues", [])
+
+        next_page_token = data.get("nextPageToken")
+        if not next_page_token or data.get("isLast", True):
+            break
+
+
+def fetch_web_links(
+    jira_url: str, headers: dict[str, str], issue_key: str
+) -> list[str]:
+    url = f"{jira_url.rstrip('/')}/rest/api/3/issue/{issue_key}/remotelink"
+    links = jira_get(url, headers)
+    return [
+        link["object"]["url"] for link in links if (link.get("object") or {}).get("url")
+    ]
+
+
+def ticket_url(jira_url: str, issue_key: str) -> str:
+    return f"{jira_url.rstrip('/')}/browse/{issue_key}"
+
+
+def gh_graphql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    if variables:
+        for key, value in variables.items():
+            cmd += ["-F", f"{key}={value}"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(f"GitHub API error:\n{result.stderr}")
+    data = json.loads(result.stdout)
+    if "errors" in data:
+        raise SystemExit(
+            f"GitHub GraphQL errors:\n{json.dumps(data['errors'], indent=2)}"
+        )
+    return data
+
+
+def fetch_github_issue_info(
+    owner: str, repo: str, number: int
+) -> tuple[str, str] | None:
+    """Return (node_id, sort_timestamp) or None if the issue is inaccessible.
+
+    sort_timestamp is the ISO-8601 timestamp of the latest comment, falling
+    back to the issue's own createdAt when there are no comments.
+    """
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          id
+          createdAt
+          comments(last: 1) {
+            nodes {
+              createdAt
+            }
+          }
+        }
+      }
+    }
+    """
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-f",
+        f"owner={owner}",
+        "-f",
+        f"repo={repo}",
+        "-F",
+        f"number={number}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None
+    data = json.loads(result.stdout)
+    issue = (data.get("data") or {}).get("repository", {}).get("issue")
+    if not issue:
+        return None
+    node_id = issue["id"]
+    created_at = issue["createdAt"]
+    comment_nodes = issue.get("comments", {}).get("nodes", [])
+    sort_ts = comment_nodes[-1]["createdAt"] if comment_nodes else created_at
+    return node_id, sort_ts
+
+
+def set_jira_field(issue_node_id: str, jira_ticket: str, dry_run: bool) -> bool:
+    if dry_run:
+        return True
+
+    mutation = """
+    mutation($issueId: ID!, $fieldId: ID!, $value: String!) {
+      setIssueFieldValue(input: {
+        issueId: $issueId
+        issueFields: [{ fieldId: $fieldId, textValue: $value }]
+      }) {
+        clientMutationId
+      }
+    }
+    """
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={mutation}",
+        "-f",
+        f"issueId={issue_node_id}",
+        "-f",
+        f"fieldId={JIRA_TICKET_FIELD_ID}",
+        "-f",
+        f"value={jira_ticket}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"    ERROR: {result.stderr.strip()}", file=sys.stderr)
+        return False
+    data = json.loads(result.stdout)
+    if "errors" in data:
+        print(f"    ERROR: {json.dumps(data['errors'])}", file=sys.stderr)
+        return False
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Set the 'Jira ticket' GitHub issue field from Jira upstream tickets.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without making any changes.",
+    )
+    parser.add_argument(
+        "--jql",
+        default=None,
+        help="Override the JQL query used to fetch Jira issues.",
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("JIRA_URL", DEFAULT_JIRA_URL),
+        help=f"Jira base URL (env JIRA_URL, default: {DEFAULT_JIRA_URL}).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    email = os.environ.get("JIRA_EMAIL")
+    token = os.environ.get("JIRA_TOKEN")
+    if not email or not token:
+        print(
+            "Set JIRA_EMAIL and JIRA_TOKEN environment variables.\n"
+            "Create a token at: https://id.atlassian.com/manage-profile/security/api-tokens",
+            file=sys.stderr,
+        )
+        return 1
+
+    jql = args.jql or DEFAULT_JQL
+    headers = auth_headers(email, token)
+
+    print(f"# JQL: {jql}", file=sys.stderr)
+    if args.dry_run:
+        print("# Dry run — no changes will be made.", file=sys.stderr)
+
+    updated = 0
+    skipped = 0
+    errors = 0
+
+    # Collect all (jira_key, owner, repo, number) tuples across all Jira issues.
+    pending: list[tuple[str, str, str, int]] = []
+    for issue in tqdm(iter_issues(args.url, headers, jql), desc="Fetching web links"):
+        key = issue["key"]
+        web_links = fetch_web_links(args.url, headers, key)
+        for link in web_links:
+            m = GITHUB_ISSUE_RE.match(link)
+            if m:
+                pending.append((key, m.group(1), m.group(2), int(m.group(3))))
+
+    # Fetch GitHub issue info and sort by the latest-activity timestamp ascending.
+    enriched: list[tuple[str, str, str, str, str, int]] = []
+    inaccessible: list[tuple[str, str, str, int]] = []
+    for key, owner, repo, number in tqdm(pending, desc="Fetching GitHub issue info"):
+        info = fetch_github_issue_info(owner, repo, number)
+        if info is None:
+            inaccessible.append((key, owner, repo, number))
+        else:
+            node_id, sort_ts = info
+            enriched.append((sort_ts, key, node_id, owner, repo, number))
+
+    enriched.sort(key=lambda t: t[0])
+
+    for key, owner, repo, number in inaccessible:
+        gh_url = f"https://github.com/{owner}/{repo}/issues/{number}"
+        print(f"{key}")
+        print(f"  SKIP  {gh_url}  (issue not found or no access)")
+        skipped += 1
+
+    for sort_ts, key, node_id, owner, repo, number in enriched:
+        gh_url = f"https://github.com/{owner}/{repo}/issues/{number}"
+        print(f"{key}")
+        action = "DRY-RUN" if args.dry_run else "SET"
+        ok = set_jira_field(node_id, key, args.dry_run)
+        if ok:
+            print(f"  {action}  {gh_url}  -> Jira ticket: {key}")
+            updated += 1
+        else:
+            print(f"  ERROR  {gh_url}")
+            errors += 1
+
+    print(
+        f"\nDone: {updated} updated, {skipped} skipped, {errors} errors.",
+        file=sys.stderr,
+    )
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
For an idea of the outcome:

- on the sidebar of the issues: 
<img width="391" height="539" alt="image" src="https://github.com/user-attachments/assets/8048b220-b028-499e-9370-85bce6364f00" />

- in the list of the issues: 
<img width="1572" height="508" alt="image" src="https://github.com/user-attachments/assets/e74cbe9c-32fd-4126-8ef4-3b9dfe17f5cb" />

TODO:
- [ ] Add a GH Action to run it regularly (not sure about the frequency, I think weekly might be enough, but at the same time… to do not tinker with the “last updated” on GitHub’ side, it might make sense to do it ASAP, so daily, ideally in the “quiet time”?)

I have also tried to preserve the order of the “last updated” on the GitHub, as adjusting the field, triggers the “modified timestamp”, so I think we could also disable it when just adding new issues.

Also looking at the current state of issues:
1. research repo doesn’t seem to be synced
2. tmt-plans are not synced
3. validation repo is not synced
4. wait-for-copr is not synced
5. epics do not seem to be synced? or at least they don’t have the matching GitHub issue linked…
6. packit/user is not synced, and there are basically no updates, so not sure what are the current plans with the repo